### PR TITLE
fix: funnel failed task requests into build results so the coordinator can have a valid stop condition

### DIFF
--- a/MuThr/MuThr.Sdk/MuThr.Sdk.csproj
+++ b/MuThr/MuThr.Sdk/MuThr.Sdk.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/MuThr/MuThr/Program.cs
+++ b/MuThr/MuThr/Program.cs
@@ -44,13 +44,10 @@ internal class Program
                 ["bar"] = new ExampleData("two"),
             }),
         };
-        
+
         private readonly BuildAction _initAction = new BypassBuildAction()
         {
             ChildTasks = [
-                new DeriveBuildAction() {
-                    SourcePath = "lhs"
-                },
                 new DeriveBuildAction() {
                     SourcePath = "rhs"
                 }
@@ -86,11 +83,7 @@ internal class Program
 #pragma warning restore CA1859 // Use concrete types when possible for improved performance
 
         Coordinator coord = new(new ExampleTaskProvider(), logger.WithChannel("Coordinator"));
-        coord.ScheduleTask("init");
-        coord.ScheduleTask("t1");
-        coord.ScheduleTask("t1");
-        coord.ScheduleTask("t1");
-        coord.ScheduleTask("t1");
+        coord.ScheduleTask("i11111nit");
 
         ImmutableDictionary<string, BuildResult> results = await coord.OutputTask.ConfigureAwait(false);
 
@@ -98,9 +91,20 @@ internal class Program
         {
             foreach (var result in results)
             {
-                using StreamReader fs = new(result.Value.OutputPath);
-                string content = await fs.ReadToEndAsync().ConfigureAwait(false);
-                logger.Information("Job result: <{key}> `{result}`", result.Key, content);
+                if (result.Value.Errors.Length > 0)
+                {
+                    foreach (var err in result.Value.Errors)
+                    {
+                        logger.Information("Job error: <{key}> {err}", result.Key, err);
+                    }
+                }
+                else
+                {
+                    using StreamReader fs = new(result.Value.OutputPath);
+                    string content = await fs.ReadToEndAsync().ConfigureAwait(false);
+                    logger.Information("Job result: <{key}> `{result}`", result.Key, content);
+                }
+
             }
         }
         finally


### PR DESCRIPTION
original design would have client wait infinitely if all task requests failed